### PR TITLE
Adding support for curly brackets on mac

### DIFF
--- a/emacs.conf
+++ b/emacs.conf
@@ -225,6 +225,7 @@
 ;; Find file like vim's Ctrlp
 (global-set-key (kbd "C-x p")  'fiplr-find-file)
 
+;; Enable curly brackets on Mac OS
 (setq mac-option-modifier nil
       mac-command-modifier 'meta
       x-select-enable-clipboard t)

--- a/emacs.conf
+++ b/emacs.conf
@@ -224,3 +224,7 @@
 
 ;; Find file like vim's Ctrlp
 (global-set-key (kbd "C-x p")  'fiplr-find-file)
+
+(setq mac-option-modifier nil
+      mac-command-modifier 'meta
+      x-select-enable-clipboard t)


### PR DESCRIPTION
With these lines mac users can type curly brackets
